### PR TITLE
V4.1.0/support for rabbitmq

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,13 +4,13 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="AWSSDK.SQS" Version="4.0.0.4" />
-    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.0.0.4" />
+    <PackageVersion Include="AWSSDK.SQS" Version="4.0.0.6" />
+    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.0.0.5" />
     <PackageVersion Include="Azure.Identity" Version="1.14.0" />
     <PackageVersion Include="Azure.Messaging.EventGrid" Version="4.31.0" />
     <PackageVersion Include="Azure.Storage.Queues" Version="12.22.0" />
     <PackageVersion Include="Codebelt.Extensions.Newtonsoft.Json" Version="9.0.3" />
-    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.1" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.2" />
     <PackageVersion Include="Codebelt.Extensions.YamlDotNet" Version="9.0.3" />
     <PackageVersion Include="Cuemon.Extensions.Collections.Generic" Version="9.0.5" />
     <PackageVersion Include="Cuemon.Extensions.Core" Version="9.0.5" />
@@ -22,9 +22,10 @@
     <PackageVersion Include="Dapper.StrongName" Version="2.1.66" />
     <PackageVersion Include="DapperExtensions.StrongNameReference" Version="1.10.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.5" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.14.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="17.14.1" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
+    <PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="Xunit.Priority" Version="1.1.6" />
@@ -32,7 +33,7 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.console" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net9'))">
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />

--- a/Savvyio.sln
+++ b/Savvyio.sln
@@ -119,6 +119,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Savvyio.Extensions.QueueSto
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Savvyio.Extensions.DependencyInjection.QueueStorage", "src\Savvyio.Extensions.DependencyInjection.QueueStorage\Savvyio.Extensions.DependencyInjection.QueueStorage.csproj", "{36520BC5-4343-4CF3-A8AE-B7A04B91DDB2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Savvyio.Extensions.RabbitMQ", "src\Savvyio.Extensions.RabbitMQ\Savvyio.Extensions.RabbitMQ.csproj", "{0AB0316F-76C4-413F-8C96-DB3489E318E6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Savvyio.Extensions.RabbitMQ.FunctionalTests", "test\Savvyio.Extensions.RabbitMQ.FunctionalTests\Savvyio.Extensions.RabbitMQ.FunctionalTests.csproj", "{C15021DF-E983-4B40-8F65-16A8966429AF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -349,6 +353,14 @@ Global
 		{36520BC5-4343-4CF3-A8AE-B7A04B91DDB2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{36520BC5-4343-4CF3-A8AE-B7A04B91DDB2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{36520BC5-4343-4CF3-A8AE-B7A04B91DDB2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0AB0316F-76C4-413F-8C96-DB3489E318E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0AB0316F-76C4-413F-8C96-DB3489E318E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0AB0316F-76C4-413F-8C96-DB3489E318E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0AB0316F-76C4-413F-8C96-DB3489E318E6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C15021DF-E983-4B40-8F65-16A8966429AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C15021DF-E983-4B40-8F65-16A8966429AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C15021DF-E983-4B40-8F65-16A8966429AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C15021DF-E983-4B40-8F65-16A8966429AF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -410,6 +422,8 @@ Global
 		{04804591-413B-4199-90E6-723097091DF9} = {407762FB-26D8-435F-AE16-C76791EC9FEC}
 		{0F265E4A-04AD-48F0-B309-22492822D91C} = {407762FB-26D8-435F-AE16-C76791EC9FEC}
 		{36520BC5-4343-4CF3-A8AE-B7A04B91DDB2} = {0E75F0C5-DBEB-4B6D-AC52-98656CA79A7D}
+		{0AB0316F-76C4-413F-8C96-DB3489E318E6} = {0E75F0C5-DBEB-4B6D-AC52-98656CA79A7D}
+		{C15021DF-E983-4B40-8F65-16A8966429AF} = {407762FB-26D8-435F-AE16-C76791EC9FEC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D8DDAD51-08E6-42B5-970B-2DC88D44297B}

--- a/src/Savvyio.Extensions.RabbitMQ/Commands/RabbitMqCommandQueue.cs
+++ b/src/Savvyio.Extensions.RabbitMQ/Commands/RabbitMqCommandQueue.cs
@@ -1,0 +1,121 @@
+﻿using Cuemon;
+using Cuemon.Extensions;
+using Cuemon.Extensions.IO;
+using Cuemon.Extensions.Reflection;
+using Cuemon.Threading;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using Savvyio.Commands;
+using Savvyio.Messaging;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace Savvyio.Extensions.RabbitMQ.Commands
+{
+    /// <summary>
+    /// Represents a RabbitMQ-based implementation of a point-to-point command queue.
+    /// </summary>
+    public class RabbitMqCommandQueue : RabbitMqMessage, IPointToPointChannel<ICommand>
+    {
+        private readonly RabbitMqCommandQueueOptions _options;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RabbitMqCommandQueue"/> class.
+        /// </summary>
+        /// <param name="marshaller">The marshaller used for serializing and deserializing messages.</param>
+        /// <param name="options">The options used to configure the RabbitMQ command queue.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="marshaller"/> cannot be null -or-
+        /// <paramref name="options"/> cannot be null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="options"/> are not in a valid state.
+        /// </exception>
+        public RabbitMqCommandQueue(IMarshaller marshaller, RabbitMqCommandQueueOptions options) : base(marshaller, options)
+        {
+            Validator.ThrowIfInvalidOptions(options);
+            _options = options;
+        }
+
+        /// <summary>
+        /// Sends the specified command messages asynchronously to the configured RabbitMQ queue.
+        /// </summary>
+        /// <param name="messages">The messages to send.</param>
+        /// <param name="setup">The <see cref="AsyncOptions"/> which may be configured.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        public async Task SendAsync(IEnumerable<IMessage<ICommand>> messages, Action<AsyncOptions> setup = null)
+        {
+            Validator.ThrowIfInvalidConfigurator(setup, out var options);
+
+            await EnsureConnectivityAsync(options.CancellationToken).ConfigureAwait(false);
+
+            await RabbitMqChannel.QueueDeclareAsync(_options.QueueName, false, false, false, cancellationToken: options.CancellationToken).ConfigureAwait(false);
+
+            foreach (var message in messages)
+            {
+                await RabbitMqChannel.BasicPublishAsync("", _options.QueueName, true, basicProperties: new BasicProperties()
+                {
+                    //Persistent = true,
+                    Headers = new Dictionary<string, object>()
+                    {
+                        { MessageType, message.GetType().ToFullNameIncludingAssemblyName() }
+                    }
+                }, body: await Marshaller.Serialize(message).ToByteArrayAsync(o => o.CancellationToken = options.CancellationToken).ConfigureAwait(false), options.CancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Receives command messages asynchronously from the configured RabbitMQ queue.
+        /// </summary>
+        /// <param name="setup">The <see cref="AsyncOptions"/> which may be configured.</param>
+        /// <returns>
+        /// An <see cref="IAsyncEnumerable{T}"/> that yields <see cref="IMessage{ICommand}"/> instances as they are received.
+        /// </returns>
+        public async IAsyncEnumerable<IMessage<ICommand>> ReceiveAsync(Action<AsyncOptions> setup = null)
+        {
+            Validator.ThrowIfInvalidConfigurator(setup, out var options);
+
+            await EnsureConnectivityAsync(options.CancellationToken).ConfigureAwait(false);
+
+            await RabbitMqChannel.QueueDeclareAsync(_options.QueueName, false, false, false, cancellationToken: options.CancellationToken).ConfigureAwait(false);
+
+            var buffer = Channel.CreateUnbounded<IMessage<ICommand>>();
+            var consumer = new AsyncEventingBasicConsumer(RabbitMqChannel);
+            consumer.ReceivedAsync += async (_, e) =>
+            {
+                var messageType = Type.GetType((e.BasicProperties.Headers[MessageType] as byte[]).ToEncodedString());
+                var deserialized = Marshaller.Deserialize(e.Body.ToArray().ToStream(), messageType) as IMessage<ICommand>;
+                deserialized!.Properties.Add(nameof(BasicDeliverEventArgs.DeliveryTag), e.DeliveryTag);
+                deserialized.Properties.Add(nameof(CancellationToken), options.CancellationToken);
+                deserialized.Properties.Add(nameof(QueueDeclareOk.QueueName), _options.QueueName);
+                await buffer.Writer.WriteAsync(deserialized, options.CancellationToken).ConfigureAwait(false);
+            };
+
+            await RabbitMqChannel.BasicConsumeAsync(_options.QueueName, autoAck: false, consumer: consumer, cancellationToken: options.CancellationToken).ConfigureAwait(false);
+
+            while (await buffer.Reader.WaitToReadAsync(options.CancellationToken).ConfigureAwait(false))
+            {
+                while (buffer.Reader.TryRead(out var message))
+                {
+                    message.Acknowledged += OnMessageAcknowledgedAsync;
+                    if (_options.AutoAcknowledge)
+                    {
+                        await message.AcknowledgeAsync().ConfigureAwait(false);
+                    }
+                    yield return message;
+                }
+            }
+        }
+
+        private async Task OnMessageAcknowledgedAsync(object sender, AcknowledgedEventArgs e)
+        {
+            var ct = (CancellationToken)e.Properties[nameof(CancellationToken)];
+            var queueName = e.Properties[nameof(QueueDeclareOk.QueueName)] as string;
+            await RabbitMqChannel.QueueDeclareAsync(queueName, false, false, false, cancellationToken: ct).ConfigureAwait(false);
+            await RabbitMqChannel.BasicAckAsync((ulong)e.Properties[nameof(BasicDeliverEventArgs.DeliveryTag)], false, ct).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Savvyio.Extensions.RabbitMQ/Commands/RabbitMqCommandQueueOptions.cs
+++ b/src/Savvyio.Extensions.RabbitMQ/Commands/RabbitMqCommandQueueOptions.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Cuemon;
+
+namespace Savvyio.Extensions.RabbitMQ.Commands
+{
+    /// <summary>
+    /// Configuration options for <see cref="RabbitMqCommandQueue"/>.
+    /// </summary>
+    /// <seealso cref="RabbitMqMessageOptions"/>
+    public class RabbitMqCommandQueueOptions : RabbitMqMessageOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RabbitMqCommandQueueOptions"/> class with default values.
+        /// </summary>
+        /// <remarks>
+        /// The following table shows the initial property values for an instance of <see cref="RabbitMqCommandQueueOptions"/>.
+        /// <list type="table">
+        ///     <listheader>
+        ///         <term>Property</term>
+        ///         <description>Initial Value</description>
+        ///     </listheader>
+        ///     <item>
+        ///         <term><see cref="QueueName"/></term>
+        ///         <description><c>null</c></description>
+        ///     </item>
+        ///     <item>
+        ///         <term><see cref="AutoAcknowledge"/></term>
+        ///         <description><c>false</c></description>
+        ///     </item>
+        /// </list>
+        /// </remarks>
+        public RabbitMqCommandQueueOptions()
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the queue.
+        /// </summary>
+        /// <value>
+        /// The name of the RabbitMQ queue to be used for command messages.
+        /// </value>
+        public string QueueName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether messages should be automatically acknowledged.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if messages are automatically acknowledged; otherwise, <c>false</c>.
+        /// </value>
+        public bool AutoAcknowledge { get; set; }
+
+        /// <summary>
+        /// Determines whether the public read-write properties of this instance are in a valid state.
+        /// </summary>
+        /// <remarks>This method is expected to throw exceptions when one or more conditions fails to be in a valid state.</remarks>
+        /// <exception cref="InvalidOperationException">
+        /// <see cref="QueueName"/> cannot be null or empty.
+        /// </exception>
+        public override void ValidateOptions()
+        {
+            Validator.ThrowIfInvalidState(string.IsNullOrEmpty(QueueName));
+            base.ValidateOptions();
+        }
+    }
+}

--- a/src/Savvyio.Extensions.RabbitMQ/EventDriven/RabbitMqEventBus.cs
+++ b/src/Savvyio.Extensions.RabbitMQ/EventDriven/RabbitMqEventBus.cs
@@ -1,0 +1,108 @@
+﻿using Cuemon;
+using Cuemon.Extensions;
+using Cuemon.Extensions.IO;
+using Cuemon.Extensions.Reflection;
+using Cuemon.Threading;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using Savvyio.EventDriven;
+using Savvyio.Messaging;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace Savvyio.Extensions.RabbitMQ.EventDriven
+{
+    /// <summary>
+    /// Represents a RabbitMQ-based implementation of a publish-subscribe event bus for integration events.
+    /// </summary>
+    public class RabbitMqEventBus : RabbitMqMessage, IPublishSubscribeChannel<IIntegrationEvent>
+    {
+        private readonly ConnectionFactory _factory;
+        private readonly RabbitMqEventBusOptions _options;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RabbitMqEventBus"/> class.
+        /// </summary>
+        /// <param name="marshaller">The marshaller used for serializing and deserializing messages.</param>
+        /// <param name="options">The options used to configure the RabbitMQ event bus.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="marshaller"/> cannot be null -or-
+        /// <paramref name="options"/> cannot be null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="options"/> are not in a valid state.
+        /// </exception>
+        public RabbitMqEventBus(IMarshaller marshaller, RabbitMqEventBusOptions options) : base(marshaller, options)
+        {
+            Validator.ThrowIfInvalidOptions(options);
+            _options = options;
+        }
+
+        /// <summary>
+        /// Publishes the specified integration event message asynchronously to the configured RabbitMQ exchange.
+        /// </summary>
+        /// <param name="message">The message to publish.</param>
+        /// <param name="setup">The <see cref="AsyncOptions"/> which may be configured.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        public async Task PublishAsync(IMessage<IIntegrationEvent> message, Action<AsyncOptions> setup = null)
+        {
+            Validator.ThrowIfInvalidConfigurator(setup, out var options);
+
+            await EnsureConnectivityAsync(options.CancellationToken).ConfigureAwait(false);
+
+            await RabbitMqChannel.ExchangeDeclareAsync(_options.ExchangeName, ExchangeType.Fanout, cancellationToken: options.CancellationToken).ConfigureAwait(false);
+
+            await RabbitMqChannel.BasicPublishAsync(_options.ExchangeName, "", false, basicProperties: new BasicProperties()
+            {
+                Headers = new Dictionary<string, object>()
+                    {
+                        { MessageType, message.GetType().ToFullNameIncludingAssemblyName() }
+                    }
+            }, body: await Marshaller.Serialize(message).ToByteArrayAsync(o => o.CancellationToken = options.CancellationToken).ConfigureAwait(false), options.CancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Subscribes to integration event messages from the configured RabbitMQ exchange and invokes the specified asynchronous handler for each received message.
+        /// </summary>
+        /// <param name="asyncHandler">The function delegate that will handle the message.</param>
+        /// <param name="setup">The <see cref="SubscribeAsyncOptions"/> which may be configured.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
+        public async Task SubscribeAsync(Func<IMessage<IIntegrationEvent>, CancellationToken, Task> asyncHandler, Action<SubscribeAsyncOptions> setup = null)
+        {
+            Validator.ThrowIfInvalidConfigurator(setup, out var options);
+
+            await EnsureConnectivityAsync(options.CancellationToken).ConfigureAwait(false);
+
+            await RabbitMqChannel.ExchangeDeclareAsync(_options.ExchangeName, ExchangeType.Fanout, cancellationToken: options.CancellationToken).ConfigureAwait(false);
+
+            var queue = await RabbitMqChannel.QueueDeclareAsync(cancellationToken: options.CancellationToken).ConfigureAwait(false);
+
+            await RabbitMqChannel.QueueBindAsync(queue.QueueName, _options.ExchangeName, "", cancellationToken: options.CancellationToken).ConfigureAwait(false);
+
+            var buffer = Channel.CreateUnbounded<IMessage<IIntegrationEvent>>();
+            var consumer = new AsyncEventingBasicConsumer(RabbitMqChannel);
+            consumer.ReceivedAsync += async (_, e) =>
+            {
+                var messageType = Type.GetType((e.BasicProperties.Headers[MessageType] as byte[]).ToEncodedString());
+                var deserialized = Marshaller.Deserialize(e.Body.ToArray().ToStream(), messageType) as IMessage<IIntegrationEvent>;
+                deserialized!.Properties.Add(nameof(BasicDeliverEventArgs.DeliveryTag), e.DeliveryTag);
+                deserialized.Properties.Add(nameof(CancellationToken), options.CancellationToken);
+                deserialized.Properties.Add(nameof(QueueDeclareOk.QueueName), queue.QueueName);
+                await buffer.Writer.WriteAsync(deserialized, options.CancellationToken).ConfigureAwait(false);
+            };
+            
+            await RabbitMqChannel.BasicConsumeAsync(queue.QueueName, autoAck: true, consumer: consumer, options.CancellationToken).ConfigureAwait(false);
+
+            while (await buffer.Reader.WaitToReadAsync(options.CancellationToken).ConfigureAwait(false))
+            {
+                while (buffer.Reader.TryRead(out var message))
+                {
+                    await asyncHandler(message, options.CancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+}

--- a/src/Savvyio.Extensions.RabbitMQ/EventDriven/RabbitMqEventBusOptions.cs
+++ b/src/Savvyio.Extensions.RabbitMQ/EventDriven/RabbitMqEventBusOptions.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Cuemon;
+
+namespace Savvyio.Extensions.RabbitMQ.EventDriven
+{
+    /// <summary>
+    /// Configuration options for <see cref="RabbitMqEventBus"/>.
+    /// </summary>
+    /// <seealso cref="RabbitMqMessageOptions"/>
+    public class RabbitMqEventBusOptions : RabbitMqMessageOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RabbitMqEventBusOptions"/> class.
+        /// </summary>
+        /// <remarks>
+        /// The following table shows the initial property values for an instance of <see cref="RabbitMqEventBusOptions"/>.
+        /// <list type="table">
+        ///     <listheader>
+        ///         <term>Property</term>
+        ///         <description>Initial Value</description>
+        ///     </listheader>
+        ///     <item>
+        ///         <term><see cref="ExchangeName"/></term>
+        ///         <description><c>null</c></description>
+        ///     </item>
+        /// </list>
+        /// </remarks>
+        public RabbitMqEventBusOptions()
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the exchange.
+        /// </summary>
+        /// <value>The name of the exchange.</value>
+        public string ExchangeName { get; set; }
+
+        /// <summary>
+        /// Determines whether the public read-write properties of this instance are in a valid state.
+        /// </summary>
+        /// <remarks>This method is expected to throw exceptions when one or more conditions fails to be in a valid state.</remarks>
+        /// <exception cref="InvalidOperationException">
+        /// <see cref="ExchangeName"/> cannot be null or empty.
+        /// </exception>
+        public override void ValidateOptions()
+        {
+            Validator.ThrowIfInvalidState(string.IsNullOrEmpty(ExchangeName));
+            base.ValidateOptions();
+        }
+    }
+}

--- a/src/Savvyio.Extensions.RabbitMQ/RabbitMqMessage.cs
+++ b/src/Savvyio.Extensions.RabbitMQ/RabbitMqMessage.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using Cuemon;
+using Cuemon.Extensions;
+using RabbitMQ.Client;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Savvyio.Extensions.RabbitMQ
+{
+    /// <summary>
+    /// Provides a base class for RabbitMQ message operations, including connection and channel management, marshalling, and resource disposal. Ensures thread-safe initialization of RabbitMQ connectivity.
+    /// </summary>
+    public abstract class RabbitMqMessage : AsyncDisposable
+    {
+        /// <summary>
+        /// The header key used to indicate the message type in RabbitMQ properties.
+        /// </summary>
+        protected const string MessageType = "type";
+
+        private readonly SemaphoreSlim _asyncLock = new(1, 1);
+        private bool _initialized;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RabbitMqMessage"/> class with the specified marshaller and options.
+        /// </summary>
+        /// <param name="marshaller">The marshaller used for serializing and deserializing messages.</param>
+        /// <param name="options">The options used to configure the RabbitMQ connection.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="marshaller"/> cannot be null -or-
+        /// <paramref name="options"/> cannot be null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="options"/> are not in a valid state.
+        /// </exception>
+        protected RabbitMqMessage(IMarshaller marshaller, RabbitMqMessageOptions options)
+        {
+            Validator.ThrowIfInvalidOptions(options);
+            Validator.ThrowIfNull(marshaller);
+            Marshaller = marshaller;
+            RabbitMqFactory = new ConnectionFactory
+            {
+                Uri = options.AmqpUrl
+            };
+        }
+
+        /// <summary>
+        /// Gets the RabbitMQ connection factory used to create connections to the broker.
+        /// </summary>
+        protected ConnectionFactory RabbitMqFactory { get; }
+
+        /// <summary>
+        /// Ensures that a connection and channel to the RabbitMQ broker are established and initialized.
+        /// This method is thread-safe and will only initialize the connection and channel once.
+        /// </summary>
+        /// <param name="ct">
+        /// A <see cref="CancellationToken"/> that can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        /// <remarks>
+        /// If the connection and channel are already initialized, this method returns immediately.
+        /// Otherwise, it acquires an asynchronous lock to ensure only one initialization occurs,
+        /// then creates the RabbitMQ connection and channel.
+        /// </remarks>
+        protected async Task EnsureConnectivityAsync(CancellationToken ct)
+        {
+            if (_initialized) { return; }
+            await _asyncLock.WaitAsync(ct).ConfigureAwait(false);
+            try
+            {
+                if (!_initialized)
+                {
+                    RabbitMqConnection = await RabbitMqFactory.CreateConnectionAsync(ct).ConfigureAwait(false);
+                    RabbitMqChannel = await RabbitMqConnection.CreateChannelAsync(cancellationToken: ct).ConfigureAwait(false);
+                    _initialized = true;
+                }
+            }
+            finally
+            {
+                _asyncLock.Release();
+            }
+        }
+
+        /// <summary>
+        /// Gets the current RabbitMQ connection instance.
+        /// </summary>
+        protected IConnection RabbitMqConnection { get; private set; }
+
+        /// <summary>
+        /// Gets the current RabbitMQ channel instance.
+        /// </summary>
+        protected IChannel RabbitMqChannel { get; private set; }
+
+        /// <summary>
+        /// Gets the by constructor provided serializer context.
+        /// </summary>
+        /// <value>The by constructor provided serializer context.</value>
+        protected IMarshaller Marshaller { get; }
+
+        /// <summary>
+        /// Called when this object is being disposed by <see cref="AsyncDisposable.DisposeAsync()"/>.
+        /// Disposes the RabbitMQ channel and connection asynchronously if they have been initialized.
+        /// </summary>
+        /// <returns>A <see cref="ValueTask"/> representing the asynchronous dispose operation.</returns>
+        protected override async ValueTask OnDisposeManagedResourcesAsync()
+        {
+            if (RabbitMqChannel != null) { await RabbitMqChannel.DisposeAsync(); }
+            if (RabbitMqConnection != null) { await RabbitMqConnection.DisposeAsync(); }
+        }
+    }
+}

--- a/src/Savvyio.Extensions.RabbitMQ/RabbitMqMessageOptions.cs
+++ b/src/Savvyio.Extensions.RabbitMQ/RabbitMqMessageOptions.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Cuemon;
+using Cuemon.Configuration;
+
+namespace Savvyio.Extensions.RabbitMQ
+{
+    /// <summary>
+    /// Configuration options that is related to RabbitMQ.
+    /// </summary>
+    /// <seealso cref="IValidatableParameterObject" />
+    public class RabbitMqMessageOptions : IValidatableParameterObject
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RabbitMqMessageOptions"/> class with default values.
+        /// </summary>
+        /// <remarks>
+        /// The following table shows the initial property values for an instance of <see cref="AmazonMessageOptions"/>.
+        /// <list type="table">
+        ///     <listheader>
+        ///         <term>Property</term>
+        ///         <description>Initial Value</description>
+        ///     </listheader>
+        ///     <item>
+        ///         <term><see cref="AmqpUrl"/></term>
+        ///         <description><c>new Uri("amqp://localhost:5672")</c></description>
+        ///     </item>
+        /// </list>
+        /// </remarks>
+        public RabbitMqMessageOptions()
+        {
+            AmqpUrl = new Uri("amqp://localhost:5672");
+        }
+
+        /// <summary>
+        /// Gets or sets the AMQP URL used to connect to the RabbitMQ broker.
+        /// </summary>
+        /// <value>
+        /// The <see cref="Uri"/> representing the AMQP endpoint for the RabbitMQ broker.
+        /// </value>
+        public Uri AmqpUrl { get; set; }
+
+        /// <summary>
+        /// Determines whether the public read-write properties of this instance are in a valid state.
+        /// </summary>
+        /// <remarks>This method is expected to throw exceptions when one or more conditions fails to be in a valid state.</remarks>
+        /// <exception cref="InvalidOperationException">
+        /// <see cref="AmqpUrl"/> cannot be null.
+        /// </exception>
+        public virtual void ValidateOptions()
+        {
+            Validator.ThrowIfInvalidState(AmqpUrl == null);
+        }
+    }
+}

--- a/src/Savvyio.Extensions.RabbitMQ/Savvyio.Extensions.RabbitMQ.csproj
+++ b/src/Savvyio.Extensions.RabbitMQ/Savvyio.Extensions.RabbitMQ.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>Extend the Savvy I/O core assemblies with support for RabbitMQ Work Queue and RabbitMQ Publish-Subscribe.</Description>
+    <PackageTags>azure queue storage event-grid bus</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Cuemon.Extensions.IO" />
+    <PackageReference Include="RabbitMQ.Client" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Savvyio.Commands\Savvyio.Commands.csproj" />
+    <ProjectReference Include="..\Savvyio.Core\Savvyio.Core.csproj" />
+    <ProjectReference Include="..\Savvyio.EventDriven.Messaging\Savvyio.EventDriven.Messaging.csproj" />
+    <ProjectReference Include="..\Savvyio.EventDriven\Savvyio.EventDriven.csproj" />
+    <ProjectReference Include="..\Savvyio.Messaging\Savvyio.Messaging.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Savvyio.Extensions.RabbitMQ.FunctionalTests/Assets/CreateMemberCommand.cs
+++ b/test/Savvyio.Extensions.RabbitMQ.FunctionalTests/Assets/CreateMemberCommand.cs
@@ -1,0 +1,20 @@
+﻿using Savvyio.Commands;
+
+namespace Savvyio.Extensions.RabbitMQ.Assets
+{
+    internal record CreateMemberCommand : Command
+    {
+        public CreateMemberCommand(string name, byte age, string emailAddress)
+        {
+            Name = name;
+            Age = age;
+            EmailAddress = emailAddress;
+        }
+
+        public string Name { get; }
+
+        public byte Age { get; }
+
+        public string EmailAddress { get; }
+    }
+}

--- a/test/Savvyio.Extensions.RabbitMQ.FunctionalTests/Assets/MemberCreated.cs
+++ b/test/Savvyio.Extensions.RabbitMQ.FunctionalTests/Assets/MemberCreated.cs
@@ -1,0 +1,17 @@
+﻿using Savvyio.EventDriven;
+
+namespace Savvyio.Extensions.RabbitMQ.Assets
+{
+    public record MemberCreated : IntegrationEvent
+    {
+        public MemberCreated(string name, string emailAddress)
+        {
+            Name = name;
+            EmailAddress = emailAddress;
+        }
+
+        public string Name { get; }
+
+        public string EmailAddress { get; }
+    }
+}

--- a/test/Savvyio.Extensions.RabbitMQ.FunctionalTests/Commands/RabbitMqCommandQueueJsonSerializerContextTest.cs
+++ b/test/Savvyio.Extensions.RabbitMQ.FunctionalTests/Commands/RabbitMqCommandQueueJsonSerializerContextTest.cs
@@ -1,0 +1,187 @@
+﻿using System.Linq;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Codebelt.Extensions.Xunit;
+using Codebelt.Extensions.Xunit.Hosting;
+using Cuemon;
+using Cuemon.Extensions;
+using Cuemon.Extensions.Collections.Generic;
+using Cuemon.Extensions.IO;
+using Microsoft.Extensions.DependencyInjection;
+using Savvyio.Commands;
+using Savvyio.Commands.Messaging;
+using Savvyio.Extensions.DependencyInjection;
+using Savvyio.Extensions.DependencyInjection.Messaging;
+using Savvyio.Extensions.RabbitMQ.Assets;
+using Savvyio.Extensions.Text.Json;
+using Savvyio.Messaging;
+using Savvyio.Messaging.Cryptography;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Savvyio.Extensions.RabbitMQ.Commands
+{
+    public class RabbitMqCommandQueueJsonSerializerContextTest : Test
+    {
+        public RabbitMqCommandQueueJsonSerializerContextTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task ReceiveAndSendAsync_CreateMemberCommand_OneTime()
+        {
+            var managed = HostTestFactory.Create(services =>
+            {
+                services.AddMarshaller<JsonMarshaller>();
+                services.AddMessageQueue<RabbitMqCommandQueue, ICommand>().AddConfiguredOptions<RabbitMqCommandQueueOptions>(o =>
+                {
+                    o.AutoAcknowledge = true;
+                    o.QueueName = "queue1";
+                });
+            });
+
+            var queue = managed.Host.Services.GetRequiredService<RabbitMqCommandQueue>();
+            var marshaller = managed.Host.Services.GetRequiredService<IMarshaller>();
+
+            var member = new CreateMemberCommand("John Doe", 44, "jd@outlook.com");
+            var urn = "https://fancy.io/members".ToUri();
+            var message = member.ToMessage(urn, nameof(CreateMemberCommand));
+            var receivedMessages = Channel.CreateUnbounded<IMessage<ICommand>>();
+
+            TestOutput.WriteLine(marshaller.Serialize(urn).ToEncodedString());
+
+            Task.Run<Task>(async () =>
+            {
+                await foreach (var msg in queue.ReceiveAsync().ConfigureAwait(false))
+                {
+                    await receivedMessages.Writer.WriteAsync(msg).ConfigureAwait(false);
+                }
+            });
+
+            await Task.Delay(200); // wait briefly to ensure subscription setup
+
+            await queue.SendAsync(message.Yield()).ConfigureAwait(false);
+
+            await Task.Delay(500);
+
+            receivedMessages.Writer.Complete(); // mark channel write is complete
+
+            var received = await receivedMessages.Reader.ReadAsync();
+
+            Assert.Equivalent(message.Data, received.Data);
+            Assert.Equivalent(message.Time, received.Time);
+            Assert.Equivalent(message.Source, received.Source);
+            Assert.Equivalent(message.Id, received.Id);
+            Assert.Equivalent(message.Type, received.Type);
+        }
+
+        [Fact]
+        public async Task ReceiveAndSendAsync_CreateMemberCommand_OneTime_Signed()
+        {
+            var managed = HostTestFactory.Create(services =>
+            {
+                services.AddMarshaller<JsonMarshaller>();
+                services.AddMessageQueue<RabbitMqCommandQueue, ICommand>().AddConfiguredOptions<RabbitMqCommandQueueOptions>(o => o.QueueName = Generate.RandomString(10));
+            });
+
+            var queue = managed.Host.Services.GetRequiredService<RabbitMqCommandQueue>();
+            var marshaller = managed.Host.Services.GetRequiredService<IMarshaller>();
+
+            var member = new CreateMemberCommand("John Doe", 44, "jd@outlook.com");
+            var urn = "https://fancy.io/members/signed".ToUri();
+            var message = member.ToMessage(urn, nameof(CreateMemberCommand)).Sign(marshaller, o => o.SignatureSecret = new byte[] { 1, 2, 3 });
+            var receivedMessages = Channel.CreateUnbounded<IMessage<ICommand>>();
+
+            TestOutput.WriteLine(marshaller.Serialize(urn).ToEncodedString());
+
+            Task.Run<Task>(async () =>
+            {
+                await foreach (var msg in queue.ReceiveAsync().ConfigureAwait(false))
+                {
+                    await receivedMessages.Writer.WriteAsync(msg).ConfigureAwait(false);
+                }
+            });
+
+            await Task.Delay(200); // wait briefly to ensure subscription setup
+
+            await queue.SendAsync(message.Yield()).ConfigureAwait(false);
+
+            await Task.Delay(500);
+
+            receivedMessages.Writer.Complete(); // mark channel write is complete
+
+            var received = (await receivedMessages.Reader.ReadAsync()) as ISignedMessage<ICommand>;
+            received?.CheckSignature(marshaller, o => o.SignatureSecret = new byte[] { 1, 2, 3 });
+
+            Assert.Equivalent(message.Data, received.Data);
+            Assert.Equivalent(message.Time, received.Time);
+            Assert.Equivalent(message.Source, received.Source);
+            Assert.Equivalent(message.Id, received.Id);
+            Assert.Equivalent(message.Type, received.Type);
+        }
+
+        [Fact]
+        public async Task ReceiveAndSendAsync_CreateMemberCommand_HundredTimes()
+        {
+            var managed = HostTestFactory.Create(services =>
+            {
+                services.AddMarshaller<JsonMarshaller>();
+                services.AddMessageQueue<RabbitMqCommandQueue, ICommand>().AddConfiguredOptions<RabbitMqCommandQueueOptions>(o => o.QueueName = Generate.RandomString(10));
+            });
+
+            var queue = managed.Host.Services.GetRequiredService<RabbitMqCommandQueue>();
+            var marshaller = managed.Host.Services.GetRequiredService<IMarshaller>();
+
+            var messages = Generate.RangeOf(100, i =>
+            {
+                var email = $"{Generate.RandomString(5)}@outlook.com";
+                var message = new CreateMemberCommand(Generate.RandomString(10), (byte)Generate.RandomNumber(byte.MaxValue), email).ToMessage($"urn:{i}:{email}".ToUri(), nameof(CreateMemberCommand));
+                return message;
+            }).ToList();
+
+            var receivedMessages = Channel.CreateUnbounded<IMessage<ICommand>>();
+
+            var count1 = 0;
+            Task.Run<Task>(async () =>
+            {
+                await foreach (var msg in queue.ReceiveAsync().ConfigureAwait(false))
+                {
+                    count1++;
+                    await receivedMessages.Writer.WriteAsync(msg).ConfigureAwait(false);
+                }
+            });
+
+            var count2 = 0;
+            Task.Run<Task>(async () =>
+            {
+                await foreach (var msg in queue.ReceiveAsync().ConfigureAwait(false))
+                {
+                    count2++;
+                    await receivedMessages.Writer.WriteAsync(msg).ConfigureAwait(false);
+                }
+            });
+
+
+            await Task.Delay(200); // wait briefly to ensure subscription setup
+
+            await queue.SendAsync(messages).ConfigureAwait(false);
+
+            await Task.Delay(750);
+
+            TestOutput.WriteLine(count1.ToString());
+            TestOutput.WriteLine(count2.ToString());
+
+            receivedMessages.Writer.Complete(); // mark channel write is complete
+
+            var received = await receivedMessages.Reader.ReadAllAsync().ToListAsync();
+
+            TestOutput.WriteLine(received.Count.ToString());
+            TestOutput.WriteLines(received.Take(10));
+
+            Assert.Equivalent(messages.Count, received.Count);
+            Assert.Equivalent(messages, received);
+            Assert.Equivalent(messages.Select(message => message.Data), received.Select(message => message.Data));
+            Assert.Equivalent(messages.Select(message => message.Data.Metadata), received.Select(message => message.Data.Metadata));
+        }
+    }
+}

--- a/test/Savvyio.Extensions.RabbitMQ.FunctionalTests/Commands/RabbitMqCommandQueueNewtonsoftJsonSerializerContextTest.cs
+++ b/test/Savvyio.Extensions.RabbitMQ.FunctionalTests/Commands/RabbitMqCommandQueueNewtonsoftJsonSerializerContextTest.cs
@@ -1,0 +1,167 @@
+﻿using System.Linq;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Codebelt.Extensions.Xunit;
+using Codebelt.Extensions.Xunit.Hosting;
+using Cuemon;
+using Cuemon.Extensions;
+using Cuemon.Extensions.Collections.Generic;
+using Cuemon.Extensions.IO;
+using Microsoft.Extensions.DependencyInjection;
+using Savvyio.Commands;
+using Savvyio.Commands.Messaging;
+using Savvyio.Extensions.DependencyInjection;
+using Savvyio.Extensions.DependencyInjection.Messaging;
+using Savvyio.Extensions.Newtonsoft.Json;
+using Savvyio.Extensions.RabbitMQ.Assets;
+using Savvyio.Messaging;
+using Savvyio.Messaging.Cryptography;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Savvyio.Extensions.RabbitMQ.Commands
+{
+    public class RabbitMqCommandQueueNewtonsoftJsonSerializerContextTest : Test
+    {
+        public RabbitMqCommandQueueNewtonsoftJsonSerializerContextTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task ReceiveAndSendAsync_CreateMemberCommand_OneTime()
+        {
+            var managed = HostTestFactory.Create(services =>
+            {
+                services.AddMarshaller<NewtonsoftJsonMarshaller>();
+                services.AddMessageQueue<RabbitMqCommandQueue, ICommand>().AddConfiguredOptions<RabbitMqCommandQueueOptions>(o => o.QueueName = Generate.RandomString(10));
+            });
+
+            var queue = managed.Host.Services.GetRequiredService<RabbitMqCommandQueue>();
+            var marshaller = managed.Host.Services.GetRequiredService<IMarshaller>();
+
+            var member = new CreateMemberCommand("John Doe", 44, "jd@outlook.com");
+            var urn = "https://fancy.io/members".ToUri();
+            var message = member.ToMessage(urn, nameof(CreateMemberCommand));
+            var receivedMessages = Channel.CreateUnbounded<IMessage<ICommand>>();
+
+            TestOutput.WriteLine(marshaller.Serialize(urn).ToEncodedString());
+
+            Task.Run<Task>(async () =>
+            {
+                await foreach (var msg in queue.ReceiveAsync().ConfigureAwait(false))
+                {
+                    await receivedMessages.Writer.WriteAsync(msg).ConfigureAwait(false);
+                }
+            });
+
+            await Task.Delay(200); // wait briefly to ensure subscription setup
+
+            await queue.SendAsync(message.Yield()).ConfigureAwait(false);
+
+            await Task.Delay(200);
+
+            receivedMessages.Writer.Complete(); // mark channel write is complete
+
+            var received = await receivedMessages.Reader.ReadAsync();
+
+            Assert.Equivalent(message.Data, received.Data);
+            Assert.Equivalent(message.Time, received.Time);
+            Assert.Equivalent(message.Source, received.Source);
+            Assert.Equivalent(message.Id, received.Id);
+            Assert.Equivalent(message.Type, received.Type);
+        }
+
+        [Fact]
+        public async Task ReceiveAndSendAsync_CreateMemberCommand_OneTime_Signed()
+        {
+            var managed = HostTestFactory.Create(services =>
+            {
+                services.AddMarshaller<NewtonsoftJsonMarshaller>();
+                services.AddMessageQueue<RabbitMqCommandQueue, ICommand>().AddConfiguredOptions<RabbitMqCommandQueueOptions>(o => o.QueueName = Generate.RandomString(10));
+            });
+
+            var queue = managed.Host.Services.GetRequiredService<RabbitMqCommandQueue>();
+            var marshaller = managed.Host.Services.GetRequiredService<IMarshaller>();
+
+            var member = new CreateMemberCommand("John Doe", 44, "jd@outlook.com");
+            var urn = "https://fancy.io/members/signed".ToUri();
+            var message = member.ToMessage(urn, nameof(CreateMemberCommand)).Sign(marshaller, o => o.SignatureSecret = new byte[] { 1, 2, 3 });
+            var receivedMessages = Channel.CreateUnbounded<IMessage<ICommand>>();
+
+            TestOutput.WriteLine(marshaller.Serialize(urn).ToEncodedString());
+
+            Task.Run<Task>(async () =>
+            {
+                await foreach (var msg in queue.ReceiveAsync().ConfigureAwait(false))
+                {
+                    await receivedMessages.Writer.WriteAsync(msg).ConfigureAwait(false);
+                }
+            });
+
+            await Task.Delay(200); // wait briefly to ensure subscription setup
+
+            await queue.SendAsync(message.Yield()).ConfigureAwait(false);
+
+            await Task.Delay(200);
+
+            receivedMessages.Writer.Complete(); // mark channel write is complete
+
+            var received = (await receivedMessages.Reader.ReadAsync()) as ISignedMessage<ICommand>;
+            received?.CheckSignature(marshaller, o => o.SignatureSecret = new byte[] { 1, 2, 3 });
+
+            Assert.Equivalent(message.Data, received.Data);
+            Assert.Equivalent(message.Time, received.Time);
+            Assert.Equivalent(message.Source, received.Source);
+            Assert.Equivalent(message.Id, received.Id);
+            Assert.Equivalent(message.Type, received.Type);
+        }
+
+        [Fact]
+        public async Task ReceiveAndSendAsync_CreateMemberCommand_HundredTimes()
+        {
+            var managed = HostTestFactory.Create(services =>
+            {
+                services.AddMarshaller<NewtonsoftJsonMarshaller>();
+                services.AddMessageQueue<RabbitMqCommandQueue, ICommand>().AddConfiguredOptions<RabbitMqCommandQueueOptions>(o => o.QueueName = Generate.RandomString(10));
+            });
+
+            var queue = managed.Host.Services.GetRequiredService<RabbitMqCommandQueue>();
+            var marshaller = managed.Host.Services.GetRequiredService<IMarshaller>();
+
+            var messages = Generate.RangeOf(100, i =>
+            {
+                var email = $"{Generate.RandomString(5)}@outlook.com";
+                var message = new CreateMemberCommand(Generate.RandomString(10), (byte)Generate.RandomNumber(byte.MaxValue), email).ToMessage($"urn:{i}:{email}".ToUri(), nameof(CreateMemberCommand));
+                return message;
+            }).ToList();
+
+            var receivedMessages = Channel.CreateUnbounded<IMessage<ICommand>>();
+            
+            Task.Run<Task>(async () =>
+            {
+                await foreach (var msg in queue.ReceiveAsync().ConfigureAwait(false))
+                {
+                    await receivedMessages.Writer.WriteAsync(msg).ConfigureAwait(false);
+                }
+            });
+
+            await Task.Delay(200); // wait briefly to ensure subscription setup
+
+            await queue.SendAsync(messages).ConfigureAwait(false);
+
+            await Task.Delay(750);
+
+            receivedMessages.Writer.Complete(); // mark channel write is complete
+
+            var received = await receivedMessages.Reader.ReadAllAsync().ToListAsync();
+
+            TestOutput.WriteLine(received.Count.ToString());
+            TestOutput.WriteLines(received.Take(10));
+
+            Assert.Equivalent(messages.Count, received.Count);
+            Assert.Equivalent(messages, received);
+            Assert.Equivalent(messages.Select(message => message.Data), received.Select(message => message.Data));
+            Assert.Equivalent(messages.Select(message => message.Data.Metadata), received.Select(message => message.Data.Metadata));
+        }
+    }
+}

--- a/test/Savvyio.Extensions.RabbitMQ.FunctionalTests/EventDriven/RabbitMqEventBusJsonSerializerContextTest.cs
+++ b/test/Savvyio.Extensions.RabbitMQ.FunctionalTests/EventDriven/RabbitMqEventBusJsonSerializerContextTest.cs
@@ -1,0 +1,298 @@
+﻿using Codebelt.Extensions.Xunit;
+using Codebelt.Extensions.Xunit.Hosting;
+using Cuemon;
+using Cuemon.Extensions;
+using Cuemon.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Savvyio.EventDriven;
+using Savvyio.EventDriven.Messaging;
+using Savvyio.EventDriven.Messaging.CloudEvents;
+using Savvyio.EventDriven.Messaging.CloudEvents.Cryptography;
+using Savvyio.Extensions.DependencyInjection;
+using Savvyio.Extensions.DependencyInjection.Messaging;
+using Savvyio.Extensions.RabbitMQ.Assets;
+using Savvyio.Extensions.Text.Json;
+using Savvyio.Messaging;
+using Savvyio.Messaging.Cryptography;
+using System.Linq;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Cuemon.Extensions.IO;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Savvyio.Extensions.RabbitMQ.EventDriven
+{
+    public class RabbitMqEventBusJsonSerializerContextTest : Test
+    {
+        public RabbitMqEventBusJsonSerializerContextTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task SubscribeAndPublishAsync_MemberCreated_OneTime()
+        {
+            var managed = HostTestFactory.Create(services =>
+            {
+                services.AddMarshaller<JsonMarshaller>();
+                services.AddMessageBus<RabbitMqEventBus, IIntegrationEvent>(o => o.Lifetime = ServiceLifetime.Singleton).AddConfiguredOptions<RabbitMqEventBusOptions>(o => o.ExchangeName = Generate.RandomString(10));
+            });
+
+            var bus = managed.Host.Services.GetRequiredService<RabbitMqEventBus>();
+            var marshaller = managed.Host.Services.GetRequiredService<IMarshaller>();
+
+            var member = new MemberCreated("John Doe", "jd@outlook.com");
+            var urn = "urn:member-events-one".ToUri();
+            var message = member.ToMessage(urn, $"{nameof(MemberCreated)}.updated-event");
+            var receivedMessages = Channel.CreateUnbounded<IMessage<IIntegrationEvent>>();
+
+            TestOutput.WriteLine(marshaller.Serialize(urn).ToEncodedString());
+            TestOutput.WriteLine(marshaller.Serialize(message).ToEncodedString());
+            
+            var handlerInvocations = 0;
+            Task.Run<Task>(async () =>
+            {
+                await bus.SubscribeAsync(async (msg, token) =>
+                {
+                    handlerInvocations++;
+                    await receivedMessages.Writer.WriteAsync(msg, token).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            });
+
+            await Task.Delay(200); // wait briefly to ensure subscription setup
+
+            await bus.PublishAsync(message).ConfigureAwait(false);
+            
+            await Task.Delay(200);
+
+            receivedMessages.Writer.Complete(); // mark channel write is complete
+            
+            var received = await receivedMessages.Reader.ReadAsync();
+
+            Assert.Equal(1, handlerInvocations);
+            Assert.Equivalent(message.Data, received.Data);
+            Assert.Equivalent(message.Time, received.Time);
+            Assert.Equivalent(message.Source, received.Source);
+            Assert.Equivalent(message.Id, received.Id);
+            Assert.Equivalent(message.Type, received.Type);
+        }
+
+        [Fact]
+        public async Task SubscribeAndPublishAsync_MemberCreated_OneTime_Signed()
+        {
+            var managed = HostTestFactory.Create(services =>
+            {
+                services.AddMarshaller<JsonMarshaller>();
+                services.AddMessageBus<RabbitMqEventBus, IIntegrationEvent>(o => o.Lifetime = ServiceLifetime.Singleton).AddConfiguredOptions<RabbitMqEventBusOptions>(o => o.ExchangeName = Generate.RandomString(10));
+            });
+
+            var bus = managed.Host.Services.GetRequiredService<RabbitMqEventBus>();
+            var marshaller = managed.Host.Services.GetRequiredService<IMarshaller>();
+
+            var member = new MemberCreated("John Doe", "jd@outlook.com");
+            var urn = "urn:member-events-one".ToUri();
+            var message = member.ToMessage(urn, $"{nameof(MemberCreated)}.updated-event.signed").Sign(marshaller, o => o.SignatureSecret = new byte[] { 1, 2, 3 });
+            var receivedMessages = Channel.CreateUnbounded<IMessage<IIntegrationEvent>>();
+
+            TestOutput.WriteLine(marshaller.Serialize(urn).ToEncodedString());
+            TestOutput.WriteLine(marshaller.Serialize(message).ToEncodedString());
+
+            var handlerInvocations = 0;
+            Task.Run<Task>(async () =>
+            {
+                await bus.SubscribeAsync(async (msg, token) =>
+                {
+                    handlerInvocations++;
+                    await receivedMessages.Writer.WriteAsync(msg, token).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            });
+
+            await Task.Delay(200); // wait briefly to ensure subscription setup
+
+            await bus.PublishAsync(message).ConfigureAwait(false);
+            
+            await Task.Delay(200);
+
+            receivedMessages.Writer.Complete(); // mark channel write is complete
+            
+            var received = await receivedMessages.Reader.ReadAsync() as ISignedMessage<IIntegrationEvent>;
+            received?.CheckSignature(marshaller, o => o.SignatureSecret = new byte[] { 1, 2, 3 });
+
+            Assert.Equal(1, handlerInvocations);
+            Assert.Equivalent(message.Data, received.Data);
+            Assert.Equivalent(message.Time, received.Time);
+            Assert.Equivalent(message.Source, received.Source);
+            Assert.Equivalent(message.Id, received.Id);
+            Assert.Equivalent(message.Type, received.Type);
+            Assert.Equivalent(message.Signature, received.Signature);
+        }
+
+        [Fact]
+        public async Task SubscribeAndPublishAsync_MemberCreated_OneTime_CloudEvent()
+        {
+            var managed = HostTestFactory.Create(services =>
+            {
+                services.AddMarshaller<JsonMarshaller>();
+                services.AddMessageBus<RabbitMqEventBus, IIntegrationEvent>(o => o.Lifetime = ServiceLifetime.Singleton).AddConfiguredOptions<RabbitMqEventBusOptions>(o => o.ExchangeName = Generate.RandomString(10));
+            });
+
+            var bus = managed.Host.Services.GetRequiredService<RabbitMqEventBus>();
+            var marshaller = managed.Host.Services.GetRequiredService<IMarshaller>();
+
+            var member = new MemberCreated("John Doe", "jd@outlook.com");
+            var urn = "urn:member-cloud-events-one".ToUri();
+            var message = member.ToMessage(urn, $"{nameof(MemberCreated)}.updated-event.cloud-event").ToCloudEvent();
+            var receivedMessages = Channel.CreateUnbounded<IMessage<IIntegrationEvent>>();
+
+            TestOutput.WriteLine(marshaller.Serialize(urn).ToEncodedString());
+            TestOutput.WriteLine(marshaller.Serialize(message).ToEncodedString());
+
+            var handlerInvocations = 0;
+            Task.Run<Task>(async () =>
+            {
+                await bus.SubscribeAsync(async (msg, token) =>
+                {
+                    handlerInvocations++;
+                    await receivedMessages.Writer.WriteAsync(msg, token).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            });
+
+            await Task.Delay(200); // wait briefly to ensure subscription setup
+            
+            await bus.PublishAsync(message);
+
+            await Task.Delay(200);
+
+            receivedMessages.Writer.Complete(); // mark channel write is complete
+            
+            var received = await receivedMessages.Reader.ReadAsync() as ICloudEvent<IIntegrationEvent>;
+
+            Assert.Equal(1, handlerInvocations);
+            Assert.Equivalent(message.Data, received.Data);
+            Assert.Equivalent(message.Time, received.Time);
+            Assert.Equivalent(message.Source, received.Source);
+            Assert.Equivalent(message.Id, received.Id);
+            Assert.Equivalent(message.Type, received.Type);
+            Assert.Equivalent(message.Specversion, received.Specversion);
+        }
+
+        [Fact]
+        public async Task SubscribeAndPublishAsync_MemberCreated_OneTime_CloudEvent_Signed()
+        {
+            var managed = HostTestFactory.Create(services =>
+            {
+                services.AddMarshaller<JsonMarshaller>();
+                services.AddMessageBus<RabbitMqEventBus, IIntegrationEvent>(o => o.Lifetime = ServiceLifetime.Singleton).AddConfiguredOptions<RabbitMqEventBusOptions>(o => o.ExchangeName = Generate.RandomString(10));
+            });
+
+            var bus = managed.Host.Services.GetRequiredService<RabbitMqEventBus>();
+            var marshaller = managed.Host.Services.GetRequiredService<IMarshaller>();
+
+            var member = new MemberCreated("John Doe", "jd@outlook.com");
+            var urn = "urn:member-events-one".ToUri();
+            var message = member.ToMessage(urn, $"{nameof(MemberCreated)}.updated-event.signed-cloud-event").ToCloudEvent().SignCloudEvent(marshaller, o => o.SignatureSecret = new byte[] { 1, 2, 3 });
+            var receivedMessages = Channel.CreateUnbounded<IMessage<IIntegrationEvent>>();
+
+            TestOutput.WriteLine(marshaller.Serialize(urn).ToEncodedString());
+            TestOutput.WriteLine(marshaller.Serialize(message).ToEncodedString());
+
+            var handlerInvocations = 0;
+            Task.Run<Task>(async () =>
+            {
+                await bus.SubscribeAsync(async (msg, token) =>
+                {
+                    handlerInvocations++;
+                    await receivedMessages.Writer.WriteAsync(msg, token).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            });
+
+            await Task.Delay(200); // wait briefly to ensure subscription setup
+
+            await bus.PublishAsync(message);
+
+            await Task.Delay(200);
+
+            receivedMessages.Writer.Complete(); // mark channel write is complete
+            
+            var received = await receivedMessages.Reader.ReadAsync() as ISignedCloudEvent<IIntegrationEvent>;
+
+            Assert.Equal(1, handlerInvocations);
+            Assert.Equivalent(message.Data, received.Data);
+            Assert.Equivalent(message.Time, received.Time);
+            Assert.Equivalent(message.Source, received.Source);
+            Assert.Equivalent(message.Id, received.Id);
+            Assert.Equivalent(message.Type, received.Type);
+            Assert.Equivalent(message.Specversion, received.Specversion);
+            Assert.Equivalent(message.Signature, received.Signature);
+        }
+
+        [Fact]
+        public async Task SubscribeAndPublishAsync_MemberCreated_HundredTimes()
+        {
+            var managed = HostTestFactory.Create(services =>
+            {
+                services.AddMarshaller<JsonMarshaller>();
+                services.AddMessageBus<RabbitMqEventBus, IIntegrationEvent>(o => o.Lifetime = ServiceLifetime.Singleton).AddConfiguredOptions<RabbitMqEventBusOptions>(o => o.ExchangeName = Generate.RandomString(10));
+            });
+
+            var bus = managed.Host.Services.GetRequiredService<RabbitMqEventBus>();
+            var marshaller = managed.Host.Services.GetRequiredService<IMarshaller>();
+
+            var messages = Generate.RangeOf(100, _ =>
+            {
+                var email = $"{Generate.RandomString(5)}@outlook.com";
+                return new MemberCreated(Generate.RandomString(10), email).ToMessage("urn:member-events-many".ToUri(), $"{nameof(MemberCreated)}");
+            }).ToList();
+            var receivedMessages1 = Channel.CreateUnbounded<IMessage<IIntegrationEvent>>();
+            var receivedMessages2 = Channel.CreateUnbounded<IMessage<IIntegrationEvent>>();
+
+            var handlerInvocations1 = 0;
+            Task.Run<Task>(async () =>
+            {
+                await bus.SubscribeAsync(async (msg, token) =>
+                {
+                    handlerInvocations1++;
+                    await receivedMessages1.Writer.WriteAsync(msg, token).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            });
+
+            var handlerInvocations2 = 0;
+            Task.Run<Task>(async () =>
+            {
+                await bus.SubscribeAsync(async (msg, token) =>
+                {
+                    handlerInvocations2++;
+                    await receivedMessages2.Writer.WriteAsync(msg, token).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            });
+
+            await Task.Delay(200); // wait briefly to ensure subscription setup
+
+            await ParallelFactory.ForEachAsync(messages, (message, token) =>
+            {
+                return bus.PublishAsync(message, o => o.CancellationToken = token);
+            }).ConfigureAwait(false);
+
+            await Task.Delay(750);
+
+            receivedMessages1.Writer.Complete(); // mark channel write is complete
+            receivedMessages2.Writer.Complete(); // mark channel write is complete
+
+            var received1 = await receivedMessages1.Reader.ReadAllAsync().ToListAsync();
+            var received2 = await receivedMessages2.Reader.ReadAllAsync().ToListAsync();
+
+            TestOutput.WriteLine(received1.Count.ToString());
+            TestOutput.WriteLines(received1.Take(10).Select(m => marshaller.Serialize(m).ToEncodedString()));
+
+            Assert.Equal(100, handlerInvocations1);
+            Assert.Equal(100, handlerInvocations2);
+            Assert.Equivalent(messages.Count, received1.Count);
+            Assert.Equivalent(messages, received1);
+            Assert.Equivalent(messages, received2);
+            Assert.Equivalent(messages.Select(message => message.Data), received1.Select(message => message.Data));
+            Assert.Equivalent(messages.Select(message => message.Data.Metadata), received1.Select(message => message.Data.Metadata));
+            Assert.Equivalent(messages.Select(message => message.Data), received2.Select(message => message.Data));
+            Assert.Equivalent(messages.Select(message => message.Data.Metadata), received2.Select(message => message.Data.Metadata));
+        }
+    }
+}

--- a/test/Savvyio.Extensions.RabbitMQ.FunctionalTests/EventDriven/RabbitMqEventBusNewtonsoftJsonSerializerContextTest.cs
+++ b/test/Savvyio.Extensions.RabbitMQ.FunctionalTests/EventDriven/RabbitMqEventBusNewtonsoftJsonSerializerContextTest.cs
@@ -1,0 +1,298 @@
+﻿using Codebelt.Extensions.Xunit;
+using Codebelt.Extensions.Xunit.Hosting;
+using Cuemon;
+using Cuemon.Extensions;
+using Cuemon.Extensions.IO;
+using Cuemon.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Savvyio.EventDriven;
+using Savvyio.EventDriven.Messaging;
+using Savvyio.EventDriven.Messaging.CloudEvents;
+using Savvyio.EventDriven.Messaging.CloudEvents.Cryptography;
+using Savvyio.Extensions.DependencyInjection;
+using Savvyio.Extensions.DependencyInjection.Messaging;
+using Savvyio.Extensions.Newtonsoft.Json;
+using Savvyio.Extensions.RabbitMQ.Assets;
+using Savvyio.Messaging;
+using Savvyio.Messaging.Cryptography;
+using System.Linq;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Savvyio.Extensions.RabbitMQ.EventDriven
+{
+    public class RabbitMqEventBusNewtonsoftJsonSerializerContextTest : Test
+    {
+         public RabbitMqEventBusNewtonsoftJsonSerializerContextTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task SubscribeAndPublishAsync_MemberCreated_OneTime()
+        {
+            var managed = HostTestFactory.Create(services =>
+            {
+                services.AddMarshaller<NewtonsoftJsonMarshaller>();
+                services.AddMessageBus<RabbitMqEventBus, IIntegrationEvent>(o => o.Lifetime = ServiceLifetime.Singleton).AddConfiguredOptions<RabbitMqEventBusOptions>(o => o.ExchangeName = Generate.RandomString(10));
+            });
+
+            var bus = managed.Host.Services.GetRequiredService<RabbitMqEventBus>();
+            var marshaller = managed.Host.Services.GetRequiredService<IMarshaller>();
+
+            var member = new MemberCreated("John Doe", "jd@outlook.com");
+            var urn = "urn:member-events-one".ToUri();
+            var message = member.ToMessage(urn, $"{nameof(MemberCreated)}.updated-event");
+            var receivedMessages = Channel.CreateUnbounded<IMessage<IIntegrationEvent>>();
+
+            TestOutput.WriteLine(marshaller.Serialize(urn).ToEncodedString());
+            TestOutput.WriteLine(marshaller.Serialize(message).ToEncodedString());
+            
+            var handlerInvocations = 0;
+            Task.Run<Task>(async () =>
+            {
+                await bus.SubscribeAsync(async (msg, token) =>
+                {
+                    handlerInvocations++;
+                    await receivedMessages.Writer.WriteAsync(msg, token).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            });
+
+            await Task.Delay(200); // wait briefly to ensure subscription setup
+
+            await bus.PublishAsync(message).ConfigureAwait(false);
+            
+            await Task.Delay(200);
+
+            receivedMessages.Writer.Complete(); // mark channel write is complete
+            
+            var received = await receivedMessages.Reader.ReadAsync();
+
+            Assert.Equal(1, handlerInvocations);
+            Assert.Equivalent(message.Data, received.Data);
+            Assert.Equivalent(message.Time, received.Time);
+            Assert.Equivalent(message.Source, received.Source);
+            Assert.Equivalent(message.Id, received.Id);
+            Assert.Equivalent(message.Type, received.Type);
+        }
+
+        [Fact]
+        public async Task SubscribeAndPublishAsync_MemberCreated_OneTime_Signed()
+        {
+            var managed = HostTestFactory.Create(services =>
+            {
+                services.AddMarshaller<NewtonsoftJsonMarshaller>();
+                services.AddMessageBus<RabbitMqEventBus, IIntegrationEvent>(o => o.Lifetime = ServiceLifetime.Singleton).AddConfiguredOptions<RabbitMqEventBusOptions>(o => o.ExchangeName = Generate.RandomString(10));
+            });
+
+            var bus = managed.Host.Services.GetRequiredService<RabbitMqEventBus>();
+            var marshaller = managed.Host.Services.GetRequiredService<IMarshaller>();
+
+            var member = new MemberCreated("John Doe", "jd@outlook.com");
+            var urn = "urn:member-events-one".ToUri();
+            var message = member.ToMessage(urn, $"{nameof(MemberCreated)}.updated-event.signed").Sign(marshaller, o => o.SignatureSecret = new byte[] { 1, 2, 3 });
+            var receivedMessages = Channel.CreateUnbounded<IMessage<IIntegrationEvent>>();
+
+            TestOutput.WriteLine(marshaller.Serialize(urn).ToEncodedString());
+            TestOutput.WriteLine(marshaller.Serialize(message).ToEncodedString());
+
+            var handlerInvocations = 0;
+            Task.Run<Task>(async () =>
+            {
+                await bus.SubscribeAsync(async (msg, token) =>
+                {
+                    handlerInvocations++;
+                    await receivedMessages.Writer.WriteAsync(msg, token).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            });
+
+            await Task.Delay(200); // wait briefly to ensure subscription setup
+
+            await bus.PublishAsync(message).ConfigureAwait(false);
+            
+            await Task.Delay(200);
+
+            receivedMessages.Writer.Complete(); // mark channel write is complete
+            
+            var received = await receivedMessages.Reader.ReadAsync() as ISignedMessage<IIntegrationEvent>;
+            received?.CheckSignature(marshaller, o => o.SignatureSecret = new byte[] { 1, 2, 3 });
+
+            Assert.Equal(1, handlerInvocations);
+            Assert.Equivalent(message.Data, received.Data);
+            Assert.Equivalent(message.Time, received.Time);
+            Assert.Equivalent(message.Source, received.Source);
+            Assert.Equivalent(message.Id, received.Id);
+            Assert.Equivalent(message.Type, received.Type);
+            Assert.Equivalent(message.Signature, received.Signature);
+        }
+
+        [Fact]
+        public async Task SubscribeAndPublishAsync_MemberCreated_OneTime_CloudEvent()
+        {
+            var managed = HostTestFactory.Create(services =>
+            {
+                services.AddMarshaller<NewtonsoftJsonMarshaller>();
+                services.AddMessageBus<RabbitMqEventBus, IIntegrationEvent>(o => o.Lifetime = ServiceLifetime.Singleton).AddConfiguredOptions<RabbitMqEventBusOptions>(o => o.ExchangeName = Generate.RandomString(10));
+            });
+
+            var bus = managed.Host.Services.GetRequiredService<RabbitMqEventBus>();
+            var marshaller = managed.Host.Services.GetRequiredService<IMarshaller>();
+
+            var member = new MemberCreated("John Doe", "jd@outlook.com");
+            var urn = "urn:member-events-one".ToUri();
+            var message = member.ToMessage(urn, $"{nameof(MemberCreated)}.updated-event.cloud-event").ToCloudEvent();
+            var receivedMessages = Channel.CreateUnbounded<IMessage<IIntegrationEvent>>();
+
+            TestOutput.WriteLine(marshaller.Serialize(urn).ToEncodedString());
+            TestOutput.WriteLine(marshaller.Serialize(message).ToEncodedString());
+
+            var handlerInvocations = 0;
+            Task.Run<Task>(async () =>
+            {
+                await bus.SubscribeAsync(async (msg, token) =>
+                {
+                    handlerInvocations++;
+                    await receivedMessages.Writer.WriteAsync(msg, token).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            });
+
+            await Task.Delay(200); // wait briefly to ensure subscription setup
+            
+            await bus.PublishAsync(message);
+
+            await Task.Delay(200);
+
+            receivedMessages.Writer.Complete(); // mark channel write is complete
+            
+            var received = await receivedMessages.Reader.ReadAsync() as ICloudEvent<IIntegrationEvent>;
+
+            Assert.Equal(1, handlerInvocations);
+            Assert.Equivalent(message.Data, received.Data);
+            Assert.Equivalent(message.Time, received.Time);
+            Assert.Equivalent(message.Source, received.Source);
+            Assert.Equivalent(message.Id, received.Id);
+            Assert.Equivalent(message.Type, received.Type);
+            Assert.Equivalent(message.Specversion, received.Specversion);
+        }
+
+        [Fact]
+        public async Task SubscribeAndPublishAsync_MemberCreated_OneTime_CloudEvent_Signed()
+        {
+            var managed = HostTestFactory.Create(services =>
+            {
+                services.AddMarshaller<NewtonsoftJsonMarshaller>();
+                services.AddMessageBus<RabbitMqEventBus, IIntegrationEvent>(o => o.Lifetime = ServiceLifetime.Singleton).AddConfiguredOptions<RabbitMqEventBusOptions>(o => o.ExchangeName = Generate.RandomString(10));
+            });
+
+            var bus = managed.Host.Services.GetRequiredService<RabbitMqEventBus>();
+            var marshaller = managed.Host.Services.GetRequiredService<IMarshaller>();
+
+            var member = new MemberCreated("John Doe", "jd@outlook.com");
+            var urn = "urn:member-events-one".ToUri();
+            var message = member.ToMessage(urn, $"{nameof(MemberCreated)}.updated-event.signed-cloud-event").ToCloudEvent().SignCloudEvent(marshaller, o => o.SignatureSecret = new byte[] { 1, 2, 3 });
+            var receivedMessages = Channel.CreateUnbounded<IMessage<IIntegrationEvent>>();
+
+            TestOutput.WriteLine(marshaller.Serialize(urn).ToEncodedString());
+            TestOutput.WriteLine(marshaller.Serialize(message).ToEncodedString());
+
+            var handlerInvocations = 0;
+            Task.Run<Task>(async () =>
+            {
+                await bus.SubscribeAsync(async (msg, token) =>
+                {
+                    handlerInvocations++;
+                    await receivedMessages.Writer.WriteAsync(msg, token).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            });
+
+            await Task.Delay(200); // wait briefly to ensure subscription setup
+
+            await bus.PublishAsync(message);
+
+            await Task.Delay(200);
+
+            receivedMessages.Writer.Complete(); // mark channel write is complete
+            
+            var received = await receivedMessages.Reader.ReadAsync() as ISignedCloudEvent<IIntegrationEvent>;
+
+            Assert.Equal(1, handlerInvocations);
+            Assert.Equivalent(message.Data, received.Data);
+            Assert.Equivalent(message.Time, received.Time);
+            Assert.Equivalent(message.Source, received.Source);
+            Assert.Equivalent(message.Id, received.Id);
+            Assert.Equivalent(message.Type, received.Type);
+            Assert.Equivalent(message.Specversion, received.Specversion);
+            Assert.Equivalent(message.Signature, received.Signature);
+        }
+
+        [Fact]
+        public async Task SubscribeAndPublishAsync_MemberCreated_HundredTimes()
+        {
+            var managed = HostTestFactory.Create(services =>
+            {
+                services.AddMarshaller<NewtonsoftJsonMarshaller>();
+                services.AddMessageBus<RabbitMqEventBus, IIntegrationEvent>(o => o.Lifetime = ServiceLifetime.Singleton).AddConfiguredOptions<RabbitMqEventBusOptions>(o => o.ExchangeName = Generate.RandomString(10));
+            });
+
+            var bus = managed.Host.Services.GetRequiredService<RabbitMqEventBus>();
+            var marshaller = managed.Host.Services.GetRequiredService<IMarshaller>();
+
+            var messages = Generate.RangeOf(100, _ =>
+            {
+                var email = $"{Generate.RandomString(5)}@outlook.com";
+                return new MemberCreated(Generate.RandomString(10), email).ToMessage("urn:member-events-many".ToUri(), $"{nameof(MemberCreated)}");
+            }).ToList();
+            var receivedMessages1 = Channel.CreateUnbounded<IMessage<IIntegrationEvent>>();
+            var receivedMessages2 = Channel.CreateUnbounded<IMessage<IIntegrationEvent>>();
+
+            var handlerInvocations1 = 0;
+            Task.Run<Task>(async () =>
+            {
+                await bus.SubscribeAsync(async (msg, token) =>
+                {
+                    handlerInvocations1++;
+                    await receivedMessages1.Writer.WriteAsync(msg, token).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            });
+
+            var handlerInvocations2 = 0;
+            Task.Run<Task>(async () =>
+            {
+                await bus.SubscribeAsync(async (msg, token) =>
+                {
+                    handlerInvocations2++;
+                    await receivedMessages2.Writer.WriteAsync(msg, token).ConfigureAwait(false);
+                }).ConfigureAwait(false);
+            });
+
+            await Task.Delay(200); // wait briefly to ensure subscription setup
+
+            await ParallelFactory.ForEachAsync(messages, (message, token) =>
+            {
+                return bus.PublishAsync(message, o => o.CancellationToken = token);
+            }).ConfigureAwait(false);
+
+            await Task.Delay(750);
+
+            receivedMessages1.Writer.Complete(); // mark channel write is complete
+            receivedMessages2.Writer.Complete(); // mark channel write is complete
+
+            var received1 = await receivedMessages1.Reader.ReadAllAsync().ToListAsync();
+            var received2 = await receivedMessages2.Reader.ReadAllAsync().ToListAsync();
+
+            TestOutput.WriteLine(received1.Count.ToString());
+            TestOutput.WriteLines(received1.Take(10));
+
+            Assert.Equal(100, handlerInvocations1);
+            Assert.Equal(100, handlerInvocations2);
+            Assert.Equivalent(messages.Count, received1.Count);
+            Assert.Equivalent(messages, received1);
+            Assert.Equivalent(messages, received2);
+            Assert.Equivalent(messages.Select(message => message.Data), received1.Select(message => message.Data));
+            Assert.Equivalent(messages.Select(message => message.Data.Metadata), received1.Select(message => message.Data.Metadata));
+            Assert.Equivalent(messages.Select(message => message.Data), received2.Select(message => message.Data));
+            Assert.Equivalent(messages.Select(message => message.Data.Metadata), received2.Select(message => message.Data.Metadata));
+        }
+    }
+}

--- a/test/Savvyio.Extensions.RabbitMQ.FunctionalTests/Savvyio.Extensions.RabbitMQ.FunctionalTests.csproj
+++ b/test/Savvyio.Extensions.RabbitMQ.FunctionalTests/Savvyio.Extensions.RabbitMQ.FunctionalTests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>Savvyio.Extensions.RabbitMQ</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Linq.Async" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Savvyio.Commands.Messaging\Savvyio.Commands.Messaging.csproj" />
+    <ProjectReference Include="..\..\src\Savvyio.EventDriven.Messaging\Savvyio.EventDriven.Messaging.csproj" />
+    <ProjectReference Include="..\..\src\Savvyio.Extensions.DependencyInjection.QueueStorage\Savvyio.Extensions.DependencyInjection.QueueStorage.csproj" />
+    <ProjectReference Include="..\..\src\Savvyio.Extensions.DependencyInjection\Savvyio.Extensions.DependencyInjection.csproj" />
+    <ProjectReference Include="..\..\src\Savvyio.Extensions.RabbitMQ\Savvyio.Extensions.RabbitMQ.csproj" />
+    <ProjectReference Include="..\..\src\Savvyio.Extensions.Newtonsoft.Json\Savvyio.Extensions.Newtonsoft.Json.csproj" />
+    <ProjectReference Include="..\..\src\Savvyio.Extensions.Text.Json\Savvyio.Extensions.Text.Json.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This pull request introduces RabbitMQ support to the project by adding new implementations for a command queue and an event bus, along with the necessary configuration options. It also includes updates to package dependencies and solution files to accommodate the new functionality.

### RabbitMQ Integration:

* Added `RabbitMqCommandQueue` class to implement a point-to-point command queue using RabbitMQ. This includes methods for sending and receiving command messages asynchronously. (`src/Savvyio.Extensions.RabbitMQ/Commands/RabbitMqCommandQueue.cs`)
* Added `RabbitMqEventBus` class to implement a publish-subscribe event bus for integration events using RabbitMQ. This includes methods for publishing and subscribing to integration events. (`src/Savvyio.Extensions.RabbitMQ/EventDriven/RabbitMqEventBus.cs`)

### Configuration Options:

* Added `RabbitMqCommandQueueOptions` class for configuring `RabbitMqCommandQueue` with properties such as `QueueName` and `AutoAcknowledge`. (`src/Savvyio.Extensions.RabbitMQ/Commands/RabbitMqCommandQueueOptions.cs`)
* Added `RabbitMqEventBusOptions` class for configuring `RabbitMqEventBus` with properties such as `ExchangeName`. (`src/Savvyio.Extensions.RabbitMQ/EventDriven/RabbitMqEventBusOptions.cs`)

### Solution and Dependency Updates:

* Updated `Directory.Packages.props` to include new versions of dependencies and add `RabbitMQ.Client` version `7.1.2`. (`Directory.Packages.props`) [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L7-R13) [[2]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L25-R36)
* Updated `Savvyio.sln` to include new projects for `Savvyio.Extensions.RabbitMQ` and its functional tests. (`Savvyio.sln`) [[1]](diffhunk://#diff-ee0757f022378c26b4952743b41fa67b6e744fbca4c10ab74c8ae530d4683df8R122-R125) [[2]](diffhunk://#diff-ee0757f022378c26b4952743b41fa67b6e744fbca4c10ab74c8ae530d4683df8R356-R363) [[3]](diffhunk://#diff-ee0757f022378c26b4952743b41fa67b6e744fbca4c10ab74c8ae530d4683df8R425-R426)